### PR TITLE
Print a rough estimation of how long the build will still last.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -88,7 +88,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "crossbeam-utils 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.6.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -201,6 +201,7 @@ dependencies = [
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "memchr 2.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "pile 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "raw-string 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "structopt 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -241,7 +242,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.2.46 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.6.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -273,7 +274,7 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "autocfg 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -547,7 +548,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum pile 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a050cc1e09fdf605fe325dd6200872e6c9a5b007b1eb2c1ba717d3e387004a3e"
 "checksum proc-macro2 0.4.24 (registry+https://github.com/rust-lang/crates.io-index)" = "77619697826f31a02ae974457af0b29b723e5619e113e9397b8b82c6bd253f09"
 "checksum quote 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)" = "53fa22a1994bd0f9372d7a816207d8a2677ad0325b073f5c5332760f0fb62b5c"
-"checksum rand 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)" = "b65e163105a6284f841bd23100a015895f54340e88a5ffc9ca7b8b33827cfce0"
+"checksum rand 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)" = "3906503e80ac6cbcacb2c2973fa8e473f24d7e2747c8c92bb230c2441cad96b5"
 "checksum rand_chacha 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "556d3a1ca6600bfcbab7c7c91ccb085ac7fbbcd70e008a98742e7847f4f7bcef"
 "checksum rand_core 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "0905b6b7079ec73b314d4c748701f6931eb79fd97c668caa3f1899b22b32c6db"
 "checksum rand_hc 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7b40677c7be09ae76218dc623efbf7b18e34bced3f38883af07bb75630a21bc4"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -45,6 +45,16 @@ version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "chrono"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "num-integer 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "clap"
 version = "2.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -196,6 +206,7 @@ name = "ninj"
 version = "0.1.0"
 dependencies = [
  "byteorder 1.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "crossbeam 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "indexmap 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -204,11 +215,25 @@ dependencies = [
  "rand 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "raw-string 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "structopt 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "nodrop"
 version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "num-integer"
+version = "0.1.39"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -459,6 +484,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "time"
+version = "0.1.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.46 (registry+https://github.com/rust-lang/crates.io-index)",
+ "redox_syscall 0.1.50 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "unicode-segmentation"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -523,6 +558,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "228047a76f468627ca71776ecdebd732a3423081fcf5125585bcd7c49886ce12"
 "checksum byteorder 1.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "94f88df23a25417badc922ab0f5716cc1330e87f71ddd9203b3a3ccd9cedf75d"
 "checksum cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "082bb9b28e00d3c9d39cc03e64ce4cea0f1bb9b3fde493f0cbc008472d22bdf4"
+"checksum chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "45912881121cb26fad7c38c17ba7daa18764771836b34fab7d3fbd93ed633878"
 "checksum clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b957d88f4b6a63b9d70d5f454ac8011819c6efa7727858f458ab71c756ce2d3e"
 "checksum cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
 "checksum crossbeam 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ad4c7ea749d9fb09e23c5cb17e3b70650860553a0e2744e38446b1803bf7db94"
@@ -541,6 +577,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum memchr 2.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "db4c41318937f6e76648f42826b1d9ade5c09cafb5aef7e351240a70f39206e9"
 "checksum memoffset 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0f9dc261e2b62d7a622bf416ea3c5245cdd5d9a7fcc428c0d06804dfce1775b3"
 "checksum nodrop 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)" = "2f9667ddcc6cc8a43afc9b7917599d7216aa09c463919ea32c59ed6cac8bc945"
+"checksum num-integer 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)" = "e83d528d2677f0518c570baf2b7abdcf0cd2d248860b68507bdcb3e91d4c0cea"
+"checksum num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "0b3a5d7cc97d6d30d8b9bc8fa19bf45349ffe46241e8816f50f62f6d6aaabee1"
 "checksum num_cpus 1.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5a69d464bdc213aaaff628444e99578ede64e9c854025aa43b9796530afa9238"
 "checksum owning_ref 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "49a4b8ea2179e6a2e27411d3bca09ca6dd630821cf6894c6c7c8467a8ee7ef13"
 "checksum parking_lot 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ab41b4aed082705d1056416ae4468b6ea99d52599ecf3169b00088d43113e337"
@@ -571,6 +609,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum syn 0.15.23 (registry+https://github.com/rust-lang/crates.io-index)" = "9545a6a093a3f0bd59adb472700acc08cad3776f860f16a897dfce8c88721cbc"
 "checksum termion 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "689a3bdfaab439fd92bc87df5c4c78417d3cbe537487274e9b0b2dce76e92096"
 "checksum textwrap 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "307686869c93e71f94da64286f9a9524c0f308a9e1c87a583de8e9c9039ad3f6"
+"checksum time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "db8dcfca086c1143c9270ac42a2bbd8a7ee477b78ac8e45b19abfb0cbede4b6f"
 "checksum unicode-segmentation 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "aa6024fc12ddfd1c6dbc14a80fa2324d4568849869b779f6bd37e5e4c03344d1"
 "checksum unicode-width 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "882386231c45df4700b275c7ff55b6f3698780a650026380e72dabe76fa46526"
 "checksum unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -212,7 +212,6 @@ dependencies = [
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "memchr 2.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "pile 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "raw-string 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "structopt 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,6 @@ byteorder = "1.2.7"
 memchr = "2.1.2"
 indexmap = "1.0.2"
 log = "0.4.6"
-rand = "0.6.4"
 chrono = "0.4.6"
 time = "0.1.42"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,8 @@ memchr = "2.1.2"
 indexmap = "1.0.2"
 log = "0.4.6"
 rand = "0.6.4"
+chrono = "0.4.6"
+time = "0.1.42"
 
 [profile.dev]
 opt-level = 3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ byteorder = "1.2.7"
 memchr = "2.1.2"
 indexmap = "1.0.2"
 log = "0.4.6"
+rand = "0.6.4"
 
 [profile.dev]
 opt-level = 3

--- a/lib/buildlog/mod.rs
+++ b/lib/buildlog/mod.rs
@@ -14,6 +14,11 @@ mod murmurhash;
 
 pub use self::murmurhash::murmur_hash_64a;
 
+fn as_millis(d: Duration) -> u32 {
+	const MILLIS_PER_SEC: u32 = 1_000;
+	d.as_secs() as u32 * MILLIS_PER_SEC + d.subsec_millis()
+}
+
 /// The latest entries for all targets in the build log.
 #[derive(Clone, Debug)]
 pub struct BuildLog {
@@ -81,8 +86,8 @@ impl BuildLog {
 			self.entries.insert(
 				output.clone(),
 				Entry {
-					start_time_ms: (starttime - build_starttime).as_millis() as u32,
-					end_time_ms: (endtime - build_starttime).as_millis() as u32,
+					start_time_ms: as_millis(starttime - build_starttime),
+					end_time_ms: as_millis(endtime - build_starttime),
 					restat_mtime: None,
 					command_hash: murmur_hash_64a(command.as_bytes()),
 				},

--- a/lib/buildlog/mod.rs
+++ b/lib/buildlog/mod.rs
@@ -23,8 +23,8 @@ pub struct BuildLog {
 /// An entry in the build log for a specific target.
 #[derive(Clone, Debug)]
 pub struct Entry {
-	pub start_time_ms: u32,
-	pub end_time_ms: u32,
+	pub start_time_ms: u64,
+	pub end_time_ms: u64,
 	pub restat_mtime: Option<Timestamp>,
 	pub command_hash: u64,
 }
@@ -188,6 +188,6 @@ fn parse_hex(s: &RawStr) -> Option<u64> {
 		.and_then(|s| u64::from_str_radix(s, 16).ok())
 }
 
-fn as_millis(d: Duration) -> u32 {
-	d.as_secs() as u32 * 1000 + d.subsec_millis()
+fn as_millis(d: Duration) -> u64 {
+	d.as_secs() * 1000 + u64::from(d.subsec_millis())
 }

--- a/lib/buildlog/mod.rs
+++ b/lib/buildlog/mod.rs
@@ -14,11 +14,6 @@ mod murmurhash;
 
 pub use self::murmurhash::murmur_hash_64a;
 
-fn as_millis(d: Duration) -> u32 {
-	const MILLIS_PER_SEC: u32 = 1_000;
-	d.as_secs() as u32 * MILLIS_PER_SEC + d.subsec_millis()
-}
-
 /// The latest entries for all targets in the build log.
 #[derive(Clone, Debug)]
 pub struct BuildLog {
@@ -39,33 +34,6 @@ impl BuildLog {
 	pub fn new() -> BuildLog {
 		BuildLog {
 			entries: BTreeMap::new(),
-		}
-	}
-
-	pub fn estimated_total_task_time(
-		&self,
-		output: &RawString,
-		_command: &RawString,
-	) -> Option<Duration> {
-		self.entries
-			.get(output)
-			.or_else(|| {
-				// TODO: Search entries for command_hash equal to murmur_hash_64a(_command)
-				None
-			})
-			.map(|entry| Duration::from_millis((entry.end_time_ms - entry.start_time_ms).into()))
-	}
-
-	pub fn average_historic_task_time(&self) -> Option<Duration> {
-		if self.entries.is_empty() {
-			None
-		} else {
-			let sum_ms: u64 = self
-				.entries
-				.iter()
-				.map(|(_, entry)| entry.end_time_ms.saturating_sub(entry.start_time_ms) as u64)
-				.sum();
-			Some(Duration::from_millis(sum_ms / self.entries.len() as u64))
 		}
 	}
 
@@ -218,4 +186,8 @@ fn parse_hex(s: &RawStr) -> Option<u64> {
 	s.to_str()
 		.ok()
 		.and_then(|s| u64::from_str_radix(s, 16).ok())
+}
+
+fn as_millis(d: Duration) -> u32 {
+	d.as_secs() as u32 * 1000 + d.subsec_millis()
 }

--- a/lib/buildlog/mod.rs
+++ b/lib/buildlog/mod.rs
@@ -6,6 +6,7 @@ use std::collections::BTreeMap;
 use std::fs::File;
 use std::io::{BufRead, BufReader, Error, ErrorKind};
 use std::path::Path;
+use std::time::Duration;
 
 mod murmurhash;
 
@@ -31,6 +32,28 @@ impl BuildLog {
 	pub fn new() -> BuildLog {
 		BuildLog {
 			entries: BTreeMap::new(),
+		}
+	}
+
+	pub fn estimated_total_task_time(&self, output: RawString, _command: RawString) -> Option<Duration> {
+		match self.entries.get(&output) {
+			Some(entry) => Some(Duration::from_millis((entry.end_time_ms - entry.start_time_ms).into())),
+			None => {
+				// TODO: Search entries for command_hash equal to murmur_hash_64a(_command)
+				None
+			},
+		}
+	}
+
+	pub fn average_historic_task_time(&self) -> Option<Duration> {
+		if self.entries.is_empty() {
+			None
+		} else {
+			let mut sum_ms = 0 as u64;
+			for (_output, entry) in self.entries.iter() {
+				sum_ms += (entry.end_time_ms - entry.start_time_ms) as u64;
+			}
+			Some(Duration::from_millis(sum_ms / self.entries.len() as u64))
 		}
 	}
 

--- a/lib/queue/mod.rs
+++ b/lib/queue/mod.rs
@@ -234,7 +234,8 @@ impl BuildQueue {
 		self.next_at(Instant::now())
 	}
 
-	/// Like next(), returns the next thing to do, but notes it as having started at the given time instead of now.
+	/// Like next(), returns the next thing to do, but notes it as having
+	/// started at the given time instead of now.
 	pub fn next_at(&mut self, start_time: Instant) -> Option<usize> {
 		let next = self.ready.pop();
 		if let Some(next) = next {
@@ -246,7 +247,7 @@ impl BuildQueue {
 					outdated: true
 				}
 			);
-			self.tasks[next].status = TaskStatus::Running {start_time};
+			self.tasks[next].status = TaskStatus::Running { start_time };
 			self.n_left -= 1;
 		}
 		next
@@ -268,7 +269,8 @@ impl BuildQueue {
 		self.complete_task_at(task, restat, Instant::now())
 	}
 
-	/// Like complete_task, marks a task as completed, but notes it as having finished at the given time instead of now.
+	/// Like complete_task, marks a task as completed, but notes it as having
+	/// finished at the given time instead of now.
 	pub fn complete_task_at(
 		&mut self,
 		task: usize,

--- a/lib/queue/mod.rs
+++ b/lib/queue/mod.rs
@@ -271,6 +271,10 @@ impl BuildQueue {
 
 	/// Like complete_task, marks a task as completed, but notes it as having
 	/// finished at the given time instead of now.
+	///
+	/// # Panics
+	/// Panics when `finish_time` is before the
+	/// [`start_time`][TaskStatus::Running::start_time] of the task.
 	pub fn complete_task_at(
 		&mut self,
 		task: usize,

--- a/src/main.rs
+++ b/src/main.rs
@@ -185,7 +185,7 @@ fn main() {
 				sleep: opt.sleep_run,
 				dep_log: &dep_log,
 				build_log: &build_log,
-				start_time: start_time,
+				start_time,
 			};
 			scope.spawn(move |_| worker.run().unwrap());
 		}

--- a/src/main.rs
+++ b/src/main.rs
@@ -101,11 +101,13 @@ fn main() {
 
 	let target_to_rule = spec.make_index();
 
-	let build_log = Mutex::new(BuildLog::read(spec.build_dir().join(".ninja_log")).unwrap_or_else(|e| {
-		error!("Error while reading .ninja_log: {}", e);
-		error!("Not using .ninja_log.");
-		BuildLog::new()
-	}));
+	let build_log = Mutex::new(
+		BuildLog::read(spec.build_dir().join(".ninja_log")).unwrap_or_else(|e| {
+			error!("Error while reading .ninja_log: {}", e);
+			error!("Not using .ninja_log.");
+			BuildLog::new()
+		}),
+	);
 
 	let dep_log = DepLogMut::open(spec.build_dir().join(".ninja_deps")).unwrap_or_else(|e| {
 		error!("Error while reading .ninja_deps: {}", e);
@@ -190,13 +192,24 @@ fn main() {
 		if opt.debug {
 			debug!("Regular output disabled because debug messages are enabled.");
 		} else {
-			show_build_status(start_time, &status, &queue, &spec, &build_log, opt.sleep_run);
+			show_build_status(
+				start_time,
+				&status,
+				&queue,
+				&spec,
+				&build_log,
+				opt.sleep_run,
+			);
 		}
 	})
 	.unwrap();
 
-	build_log.lock().unwrap().write(spec.build_dir().join(".ninja_log")).unwrap_or_else(|e| {
-		eprintln!("Unable to store logfile: {}", e);
-		exit(1);
-	});
+	build_log
+		.into_inner()
+		.unwrap()
+		.write(spec.build_dir().join(".ninja_log"))
+		.unwrap_or_else(|e| {
+			eprintln!("Unable to store logfile: {}", e);
+			exit(1);
+		});
 }

--- a/src/status.rs
+++ b/src/status.rs
@@ -1,5 +1,6 @@
 use crate::timeformat::MinSec;
 use crate::worker::StatusUpdater;
+use ninj::buildlog::BuildLog;
 use ninj::queue::{AsyncBuildQueue, TaskStatus};
 use ninj::spec::Spec;
 use std::sync::{Condvar, Mutex};
@@ -13,6 +14,7 @@ enum WorkerStatus {
 	Done,
 }
 
+#[derive(Clone)]
 struct BuildStatusInner {
 	workers: Vec<WorkerStatus>,
 	dirty: bool,
@@ -36,8 +38,7 @@ impl BuildStatus {
 
 	fn set_status(&self, worker: usize, status: WorkerStatus) {
 		let mut lock = self.inner.lock().unwrap();
-		lock.workers[worker] = status;
-		lock.dirty = true;
+		lock.set_status(worker, status);
 		self.condvar.notify_all();
 	}
 }
@@ -57,11 +58,39 @@ impl StatusUpdater for BuildStatus {
 	}
 }
 
+impl BuildStatusInner {
+	fn set_status(&mut self, worker: usize, status: WorkerStatus) {
+		self.workers[worker] = status;
+		self.dirty = true;
+	}
+
+	fn all_workers_done(&self) -> bool {
+		self.workers.iter().all(|worker| *worker == WorkerStatus::Done)
+	}
+
+	fn all_workers_done_or_idle(&self) -> bool {
+		self.workers.iter().all(|worker| *worker == WorkerStatus::Done || *worker == WorkerStatus::Idle)
+	}
+}
+
+fn estimated_total_task_time(spec: &Spec, task: usize, build_log: &std::sync::MutexGuard<BuildLog>) -> Option<Duration> {
+	let rule = &spec.build_rules[task];
+	let command = &rule.command.as_ref().expect("Got phony task").command;
+
+	if rule.outputs.len() == 0 {
+		build_log.average_historic_task_time()
+	} else {
+		let output = &rule.outputs[0];
+		build_log.estimated_total_task_time(output.clone(), command.clone()).or_else(||{ build_log.average_historic_task_time() })
+	}
+}
+
 pub fn show_build_status(
 	start_time: Instant,
 	status: &BuildStatus,
 	queue: &AsyncBuildQueue,
 	spec: &Spec,
+	build_log: &BuildLog,
 	sleep: bool,
 ) {
 	let mut lock = status.inner.lock().unwrap();
@@ -74,12 +103,12 @@ pub fn show_build_status(
 			now = Instant::now();
 		}
 		let queuelock = queue.lock();
-		let queuestate = queuelock.clone_queue();
+		let mut queuestate = queuelock.clone_queue();
 		drop(queuelock);
-		let workers = lock.workers.clone();
+		let mut buildstate = lock.clone();
 		lock.dirty = false;
 		drop(lock);
-		for worker in &workers {
+		for worker in &buildstate.workers {
 			match worker {
 				WorkerStatus::Starting => {
 					println!("=> \x1b[34mStarting...\x1b[K\x1b[m");
@@ -109,11 +138,90 @@ pub fn show_build_status(
 				}
 			}
 		}
-		println!("Building for {}...", MinSec::since(start_time));
-		if workers.iter().all(|worker| *worker == WorkerStatus::Done) {
+
+		let build_is_done = buildstate.all_workers_done();
+
+		// Compute remaining time for this build, by simulating a build.
+		let mut simulated_time = Instant::now();
+		let mut estimation_impossible = false;
+		while !buildstate.all_workers_done_or_idle() {
+			// Give all simulated workers something to do
+			for i in 0..buildstate.workers.len() {
+				let worker = &buildstate.workers[i];
+				match worker {
+					WorkerStatus::Starting | WorkerStatus::Idle => {
+						let next = queuestate.next_at(simulated_time);
+						buildstate.set_status(i, match next {
+							Some(task) => WorkerStatus::Running{task},
+							None => WorkerStatus::Idle,
+						});
+					}
+					_ => {}
+				}
+			}
+
+			// Find the job with the lowest remaining time
+			let earliest_remaining_job = match buildstate.workers.iter()
+				.enumerate()
+				.flat_map(|(i, worker)| {
+					match worker {
+						WorkerStatus::Running{task, ..} => {
+							let taskstatus = queuestate.get_task_status(*task);
+							match taskstatus {
+								TaskStatus::Running{start_time, ..} => {
+									let runtime = if simulated_time > start_time { simulated_time - start_time } else { Duration::from_millis(0) };
+									match estimated_total_task_time(spec, *task, build_log) {
+										Some(time) => Some((i, task, time.checked_sub(runtime).unwrap_or(Duration::from_millis(0)))),
+										None => None,
+									}
+								},
+								TaskStatus::Finished{..} => Some((i, task, Duration::from_millis(0))),
+								_ => unreachable!(),
+							}
+						},
+						_ => None,
+					}
+				})
+				.min_by_key(|&(_, _, time)| time)
+			{
+				Some(earliest_remaining_job) => earliest_remaining_job,
+				None => {
+					estimation_impossible = true;
+					break;
+				}
+			};
+
+			// Pass that time
+			simulated_time += earliest_remaining_job.2;
+
+			// Complete that task, if it isn't already Finished
+			match queuestate.get_task_status(*earliest_remaining_job.1) {
+				TaskStatus::Running{ .. } => {queuestate.complete_task_at(*earliest_remaining_job.1, None, simulated_time);},
+				TaskStatus::Finished{ .. } => {},
+				_ => unreachable!(),
+			};
+
+			// Mark that worker as finished so it gets a new job next round
+			let i = earliest_remaining_job.0;
+			drop(earliest_remaining_job);
+			buildstate.workers[i] = WorkerStatus::Idle;
+		}
+
+		let now = Instant::now();
+
+		if estimation_impossible || simulated_time <= now {
+			println!("Building for {}, estimating remaining time...\x1b[K\x1b[m",
+				MinSec::since(start_time));
+		} else {
+			println!("Building for {}, remaining time for build is {}\x1b[K\x1b[m",
+				MinSec::since(start_time), MinSec::from_duration(simulated_time - now));
+		}
+
+		if build_is_done {
 			break;
 		}
-		print!("\x1b[{}A", workers.len() + 1);
+
+		print!("\x1b[{}A", buildstate.workers.len() + 1);
 		lock = status.inner.lock().unwrap();
 	}
 	println!("\x1b[32;1mFinished.\x1b[m");

--- a/src/status.rs
+++ b/src/status.rs
@@ -81,10 +81,6 @@ fn estimated_total_task_time(
 		if let Some(estimate_ms) = build_log
 			.entries
 			.get(*output)
-			.or_else(|| {
-				// TODO: Find an entry where command_hash is equal to murmur_hash_64a(command)
-				None
-			})
 			.and_then(|entry| entry.end_time_ms.checked_sub(entry.start_time_ms))
 		{
 			return Some(Duration::from_millis(estimate_ms.into()));

--- a/src/status.rs
+++ b/src/status.rs
@@ -90,7 +90,7 @@ pub fn show_build_status(
 	status: &BuildStatus,
 	queue: &AsyncBuildQueue,
 	spec: &Spec,
-	build_log: &BuildLog,
+	build_log: &Mutex<BuildLog>,
 	sleep: bool,
 ) {
 	let mut lock = status.inner.lock().unwrap();
@@ -170,7 +170,7 @@ pub fn show_build_status(
 							match taskstatus {
 								TaskStatus::Running{start_time, ..} => {
 									let runtime = if simulated_time > start_time { simulated_time - start_time } else { Duration::from_millis(0) };
-									match estimated_total_task_time(spec, *task, build_log) {
+									match estimated_total_task_time(spec, *task, &build_log.lock().unwrap()) {
 										Some(time) => Some((i, task, time.checked_sub(runtime).unwrap_or(Duration::from_millis(0)))),
 										None => None,
 									}

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -55,7 +55,7 @@ impl<'a> Worker<'a> {
 			sleep,
 			dep_log,
 			build_log,
-			start_time
+			start_time,
 		} = self;
 		let log = format!("ninj::worker-{}", id);
 		let mut lock = queue.lock();
@@ -144,7 +144,12 @@ impl<'a> Worker<'a> {
 					restat = None;
 				}
 			}
-			build_log.lock().unwrap().add_entry(&spec.build_rules[task], start_time, worker_start_time, Instant::now());
+			build_log.lock().unwrap().add_entry(
+				&spec.build_rules[task],
+				start_time,
+				worker_start_time,
+				Instant::now(),
+			);
 			lock = queue.lock();
 			lock.complete_task(task, restat);
 		}


### PR DESCRIPTION
Every time the build status is printed, perform a simulation of the rest of the
build so we can add an estimation to the build status. For this simulation,
historic build times from the Ninja log are used. If a build is started without
any Ninja log present, an estimation cannot yet be made.

To do:

- [x] Update the BuildLog with our runtimes for every finished job, and write the
log to .ninja_log at exit. This will allow immediate showing of estimations
even without a pre-existing ninja log, and will make future estimations more
accurate.
- [x] Move this code into a separate function that receives queue and worker state,
  and returns an Option<Duration>.
- [ ] Since this code may take a long time to run in larger projects, perhaps we
  shouldn't run it for every print of the build status, but allow it to
  recompute less frequently and just print the estimation minus elapsed time
  since calculation.
- [ ] Add a pretty progress bar.

The last two entries will be done in later PRs as necessary.