### PR TITLE
Improve display of the current progress.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -160,6 +160,15 @@ version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "kernel32-sys"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -214,6 +223,7 @@ dependencies = [
  "pile 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "raw-string 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "structopt 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "term_size 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -465,6 +475,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "term_size"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.46 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "termion"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -532,12 +552,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "winapi"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "winapi"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "winapi-build"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "winapi-i686-pc-windows-gnu"
@@ -569,6 +599,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum fuchsia-zircon-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
 "checksum heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "20564e78d53d2bb135c343b3f47714a56af2061f1c928fdb541dc7b9fdd94205"
 "checksum indexmap 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7e81a7c05f79578dbc15793d8b619db9ba32b4577003ef3af1a91c416798c58d"
+"checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
 "checksum lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a374c89b9db55895453a74c1e38861d9deec0b01b405a82516e9d5de4820dea1"
 "checksum libc 0.2.46 (registry+https://github.com/rust-lang/crates.io-index)" = "023a4cd09b2ff695f9734c1934145a315594b7986398496841c7031a5a1bbdbd"
 "checksum lock_api 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "62ebf1391f6acad60e5c8b43706dde4582df75c06698ab44511d15016bc2442c"
@@ -606,6 +637,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum structopt 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)" = "670ad348dc73012fcf78c71f06f9d942232cdd4c859d4b6975e27836c3efc0c3"
 "checksum structopt-derive 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)" = "ef98172b1a00b0bec738508d3726540edcbd186d50dfd326f2b1febbb3559f04"
 "checksum syn 0.15.23 (registry+https://github.com/rust-lang/crates.io-index)" = "9545a6a093a3f0bd59adb472700acc08cad3776f860f16a897dfce8c88721cbc"
+"checksum term_size 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "9e5b9a66db815dcfd2da92db471106457082577c3c278d4138ab3e3b4e189327"
 "checksum termion 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "689a3bdfaab439fd92bc87df5c4c78417d3cbe537487274e9b0b2dce76e92096"
 "checksum textwrap 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "307686869c93e71f94da64286f9a9524c0f308a9e1c87a583de8e9c9039ad3f6"
 "checksum time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "db8dcfca086c1143c9270ac42a2bbd8a7ee477b78ac8e45b19abfb0cbede4b6f"
@@ -616,6 +648,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum vec_map 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "05c78687fb1a80548ae3250346c3db86a80a7cdd77bda190189f2d0a0987c81a"
 "checksum version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd"
 "checksum void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
+"checksum winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
 "checksum winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "92c1eb33641e276cfa214a0522acad57be5c56b10cb348b3c5117db75f3ac4b0"
+"checksum winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc"
 "checksum winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 "checksum winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ indexmap = "1.0.2"
 log = "0.4.6"
 chrono = "0.4.6"
 time = "0.1.42"
+term_size = "0.3"
 
 [profile.dev]
 opt-level = 3

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,7 +5,7 @@ mod timeformat;
 mod worker;
 
 use self::logger::Logger;
-use self::status::{show_build_status, BuildStatus};
+use self::status::{show_build_status, BuildStatus, ProgressFormat};
 use self::worker::Worker;
 use log::{debug, error};
 use ninj::buildlog::BuildLog;
@@ -60,6 +60,10 @@ struct Options {
 	/// Enable debug messages.
 	#[structopt(long)]
 	debug: bool,
+
+	/// Set format of progress indication (none/text/ascii/highres).
+	#[structopt(short = "P", long = "progress", default_value = "highres")]
+	progress: ProgressFormat,
 }
 
 fn main() {
@@ -199,6 +203,7 @@ fn main() {
 				&spec,
 				&build_log,
 				opt.sleep_run,
+				opt.progress,
 			);
 		}
 	})

--- a/src/status.rs
+++ b/src/status.rs
@@ -317,7 +317,7 @@ pub fn show_build_status(
 					/ as_millis(current_duration + remaining_duration) as f64;
 				(
 					progress,
-					format!("{:02}%", (progress * 100.).ceil() as u8),
+					format!("{:02}%", (progress * 100.) as u8),
 					format!("{}", MinSec::from_duration(remaining_duration)),
 					{
 						let eta = chrono::Local::now()

--- a/src/status.rs
+++ b/src/status.rs
@@ -1,3 +1,5 @@
+mod progressbar;
+
 use crate::timeformat::MinSec;
 use crate::worker::StatusUpdater;
 use ninj::buildlog::BuildLog;

--- a/src/status.rs
+++ b/src/status.rs
@@ -374,7 +374,8 @@ pub fn show_build_status(
 					percentagetext,
 					ProgressBar {
 						progress,
-						width: terminal_width().saturating_sub(etatext.len() + percentagetext.len() + 9),
+						width: terminal_width()
+							.saturating_sub(etatext.len() + percentagetext.len() + 9),
 						ascii: progress_format == ProgressFormat::ASCIISplitBar,
 						label: &text,
 					},

--- a/src/status.rs
+++ b/src/status.rs
@@ -3,6 +3,7 @@ use crate::worker::StatusUpdater;
 use ninj::buildlog::BuildLog;
 use ninj::queue::{AsyncBuildQueue, TaskStatus};
 use ninj::spec::Spec;
+use std::fmt;
 use std::sync::{Condvar, Mutex};
 use std::time::{Duration, Instant};
 use time::Duration as TimeDuration;
@@ -103,6 +104,120 @@ fn estimated_total_task_time(
 	}
 }
 
+#[derive(Debug, Clone, PartialEq)]
+pub enum ProgressFormat {
+	None,
+	Text,
+	ASCIIBar,
+	HighResBar,
+}
+
+#[derive(Debug)]
+pub struct ParseProgressFormatError {
+	value: String,
+}
+
+impl core::str::FromStr for ProgressFormat {
+	type Err = ParseProgressFormatError;
+	fn from_str(s: &str) -> Result<Self, ParseProgressFormatError> {
+		let s = s.to_lowercase();
+		if s == "none" {
+			Ok(ProgressFormat::None)
+		} else if s == "text" {
+			Ok(ProgressFormat::Text)
+		} else if s == "ascii" {
+			Ok(ProgressFormat::ASCIIBar)
+		} else if s == "highres" {
+			Ok(ProgressFormat::HighResBar)
+		} else {
+			Err(ParseProgressFormatError { value: s })
+		}
+	}
+}
+
+impl fmt::Display for ParseProgressFormatError {
+	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+		write!(f, "{}", self.value)
+	}
+}
+
+fn render_progress_bar(width: usize, percentage: f32, text: &String, highres: bool) -> String {
+	while text.len() > width {
+		return String::from(text.split_at(width).0);
+	}
+
+	let textwidth = text.len();
+	let spaceleft = (width - textwidth) / 2;
+	let spaceright = width - textwidth - spaceleft;
+
+	let arrow_width = percentage * width as f32 / 100.;
+	let arrow_full_char = if highres { "▉" } else { "=" };
+	let arrow_cut_char = if highres { "▋" } else { arrow_full_char };
+
+	let arrow_rest = arrow_width - arrow_width.floor();
+	let arrow_rest_char = if arrow_rest < 0.01 {
+		""
+	} else if !highres {
+		">"
+	} else if arrow_rest > 0.84 {
+		"▊"
+	} else if arrow_rest > 0.68 {
+		"▋"
+	} else if arrow_rest > 0.52 {
+		"▌"
+	} else if arrow_rest > 0.36 {
+		"▍"
+	} else if arrow_rest > 0.20 {
+		"▎"
+	} else {
+		"▏"
+	};
+
+	// If highres, the arrow characters are all 3 bytes. This is assumed below.
+	let arrow_charlen = if highres { 3 } else { 1 };
+	assert!(arrow_full_char.len() == arrow_charlen);
+	assert!(arrow_rest_char.is_empty() || arrow_rest_char.len() == arrow_charlen);
+
+	let arrow = arrow_full_char.repeat(arrow_width.floor() as usize) + arrow_rest_char;
+	let arrowlen = arrow.chars().count();
+
+	let left = if arrowlen < spaceleft {
+		format!("{}{}", arrow, " ".repeat(spaceleft - arrowlen))
+	} else {
+		format!(
+			"{}{}",
+			arrow.split_at((spaceleft - 1) * arrow_charlen).0,
+			arrow_cut_char
+		)
+	};
+	let lefttextlen = spaceleft + textwidth;
+	let right = if arrowlen < lefttextlen {
+		" ".repeat(spaceright)
+	} else if arrowlen == width {
+		format!(
+			"{}{}",
+			arrow
+				.split_at(lefttextlen * arrow_charlen)
+				.1
+				.split_at((spaceright - 1) * arrow_charlen)
+				.0,
+			arrow_cut_char
+		)
+	} else {
+		format!(
+			"{}{}",
+			arrow.split_at(lefttextlen * arrow_charlen).1,
+			" ".repeat(width - arrowlen)
+		)
+	};
+
+	assert!(left.chars().count() == spaceleft);
+	assert!(right.chars().count() == spaceright);
+	assert!(spaceleft + text.chars().count() + spaceright == width);
+
+	format!("\x1b[32m{}\x1b[m{}\x1b[32m{}\x1b[m", left, text, right)
+}
+
 pub fn show_build_status(
 	start_time: Instant,
 	status: &BuildStatus,
@@ -110,6 +225,7 @@ pub fn show_build_status(
 	spec: &Spec,
 	build_log: &Mutex<BuildLog>,
 	sleep: bool,
+	progress_format: ProgressFormat,
 ) {
 	let mut lock = status.inner.lock().unwrap();
 	println!("{}:", if sleep { "Sleeping" } else { "Building" });
@@ -181,11 +297,11 @@ pub fn show_build_status(
 				}
 			}
 
-			// All workers still idle? Nothing else to do, stop simulating
+			// All workers still idle or done? Nothing else to do, stop simulating
 			if buildstate
 				.workers
 				.iter()
-				.find(|&w| *w != WorkerStatus::Idle)
+				.find(|&w| *w != WorkerStatus::Idle && *w != WorkerStatus::Done)
 				.is_none()
 			{
 				break;
@@ -224,6 +340,8 @@ pub fn show_build_status(
 			{
 				Some(earliest_remaining_job) => earliest_remaining_job,
 				None => {
+					// This happens when workers are working on a job for which we cannot
+					// guess how long it will take.
 					estimation_impossible = true;
 					break;
 				}
@@ -247,44 +365,95 @@ pub fn show_build_status(
 
 		let now = Instant::now();
 
-		if estimation_impossible || simulated_time <= now {
-			println!(
-				"Building for {}, estimating remaining time...\x1b[K\x1b[m",
-				MinSec::since(start_time)
-			);
+		let current_duration = start_time.elapsed();
+		let remaining_duration = if estimation_impossible {
+			None
+		} else if simulated_time < now {
+			// Should have been done already, estimate it will be done immediately
+			Some(Duration::from_millis(0))
 		} else {
-			let remaining_duration = simulated_time - now;
-			let eta = TimeDuration::from_std(remaining_duration)
-				.map(|duration| chrono::Local::now() + duration);
-			match eta {
-				Ok(eta) => {
-					let is_soon = eta.date() == chrono::Local::now().date()
-						&& remaining_duration < Duration::from_secs(8 * 3600);
-					let timeformat = if is_soon {
-						"%H:%M:%S"
+			Some(simulated_time - now)
+		};
+
+		let (percentage, text) = match remaining_duration {
+			None => (0., format!("??% (estimating time)")),
+			Some(remaining_duration) => {
+				let percentage = (100 * as_millis(current_duration)) as f32
+					/ as_millis(current_duration + remaining_duration) as f32;
+
+				// Every 5 seconds, switch between showing ETA and remaining duration
+				let show_eta = (current_duration.as_secs() % 10) > 5;
+
+				(
+					percentage,
+					if show_eta {
+						let eta = TimeDuration::from_std(remaining_duration)
+							.map(|duration| chrono::Local::now() + duration)
+							.unwrap();
+						let is_soon = eta.date() == chrono::Local::now().date()
+							&& remaining_duration < Duration::from_secs(8 * 3600);
+						let timeformat = if is_soon {
+							"%H:%M:%S"
+						} else {
+							"%Y-%m-%d %H:%M:%S"
+						};
+						format!(
+							"{}% (ETA {})",
+							percentage.ceil() as u8,
+							eta.format(timeformat)
+						)
 					} else {
-						"%Y-%m-%d %H:%M:%S"
-					};
-					println!(
-						"Building for {}, remaining time for build is {} (ETA {})\x1b[K\x1b[m",
-						MinSec::since(start_time),
-						MinSec::from_duration(remaining_duration),
-						eta.format(timeformat)
-					);
-				}
-				_ => println!(
-					"Building for {}, remaining time is infinite...\x1b[K\x1b[m",
-					MinSec::since(start_time)
-				),
+						format!(
+							"{}% ({} remaining)",
+							percentage.ceil() as u8,
+							MinSec::from_duration(remaining_duration)
+						)
+					},
+				)
 			}
-		}
+		};
+
+		let progress = match progress_format {
+			ProgressFormat::None => "".to_owned(),
+			ProgressFormat::Text => format!(
+				"[Building for {}, {}]\x1b[K\x1b[m\n",
+				MinSec::since(start_time),
+				text
+			),
+			ProgressFormat::ASCIIBar | ProgressFormat::HighResBar => format!(
+				"[{}]\x1b[K\x1b[m\n",
+				render_progress_bar(
+					terminal_width() - 3,
+					percentage,
+					&text,
+					progress_format == ProgressFormat::HighResBar
+				)
+			),
+		};
+
+		print!("{}", progress);
 
 		if build_is_done {
 			break;
 		}
 
-		print!("\x1b[{}A", buildstate.workers.len() + 1);
+		print!(
+			"\x1b[{}A",
+			buildstate.workers.len() + progress.lines().count()
+		);
 		lock = status.inner.lock().unwrap();
 	}
 	println!("\x1b[32;1mFinished.\x1b[m");
+}
+
+fn terminal_width() -> usize {
+	if let Some((w, _)) = term_size::dimensions() {
+		w
+	} else {
+		80 /* an educated guess */
+	}
+}
+
+fn as_millis(d: Duration) -> u64 {
+	d.as_secs() * 1000 + u64::from(d.subsec_millis())
 }

--- a/src/status.rs
+++ b/src/status.rs
@@ -374,7 +374,7 @@ pub fn show_build_status(
 					percentagetext,
 					ProgressBar {
 						progress,
-						width: terminal_width() - etatext.len() - percentagetext.len() - 9,
+						width: terminal_width().saturating_sub(etatext.len() + percentagetext.len() + 9),
 						ascii: progress_format == ProgressFormat::ASCIISplitBar,
 						label: &text,
 					},

--- a/src/status/progressbar.rs
+++ b/src/status/progressbar.rs
@@ -9,43 +9,38 @@ pub struct ProgressBar<'a> {
 
 impl<'a> std::fmt::Display for ProgressBar<'a> {
 	fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-		if self.label.len() > self.width {
-			f.write_str(&self.label[..self.width])?;
-			return Ok(());
-		}
-
-		let fancy_blocks = [' ', '▏', '▎', '▍', '▌', '▋', '▊', '▉'];
-
-		let ticks = (self.progress * self.width as f64 * fancy_blocks.len() as f64) as usize;
-		let label_pos = (self.width - self.label.len()) / 2;
+		let blocks = [' ', '▏', '▎', '▍', '▌', '▋', '▊', '▉'];
+		let ticks = (self.progress * self.width as f64 * blocks.len() as f64) as usize;
+		let label_pos = self.width.saturating_sub(self.label.len()) / 2;
 		f.write_str("\x1b[32m")?;
 		let mut i = 0;
 		while i < self.width {
-			if i == label_pos && !self.label.is_empty() {
-				f.write_str("\x1b[m")?;
-				f.write_str(self.label)?;
-				f.write_str("\x1b[32m")?;
-				i += self.label.len();
+			if i >= label_pos && i < label_pos + self.label.len() {
+				f.write_str(if i < ticks / blocks.len() {
+					"\x1b[32;7m"
+				} else {
+					"\x1b[m"
+				})?;
+				f.write_str(&self.label[i - label_pos..][..1])?;
+				f.write_str("\x1b[27;32m")?;
 			} else {
-				f.write_char(if i < ticks / fancy_blocks.len() {
+				f.write_char(if i < ticks / blocks.len() {
 					if self.ascii {
 						'='
-					} else if i + 1 == label_pos {
-						fancy_blocks[5]
 					} else {
-						fancy_blocks[7]
+						'█'
 					}
-				} else if i == ticks / fancy_blocks.len() {
+				} else if i == ticks / blocks.len() {
 					if self.ascii {
 						'>'
 					} else {
-						fancy_blocks[ticks % 8]
+						blocks[ticks % 8]
 					}
 				} else {
 					' '
 				})?;
-				i += 1;
 			}
+			i += 1;
 		}
 		f.write_str("\x1b[m")?;
 		Ok(())

--- a/src/status/progressbar.rs
+++ b/src/status/progressbar.rs
@@ -1,0 +1,32 @@
+use std::fmt::Write;
+
+pub struct ProgressBar<'a> {
+	pub progress: f64,
+	pub width: usize,
+	pub ascii: bool,
+	pub label: &'a str,
+}
+
+impl<'a> std::fmt::Display for ProgressBar<'a> {
+	fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+		let ticks = (self.progress * self.width as f64 * 8.0) as usize;
+		let label_pos = (self.width - self.label.len()) / 2;
+		let mut i = 0;
+		while i < self.width {
+			if i == label_pos && !self.label.is_empty() {
+				f.write_str(self.label)?;
+				i += self.label.len();
+			} else {
+				f.write_char(if i < ticks / 8 {
+					if self.ascii { '=' } else if i + 1 == label_pos { '▉' } else { '█' }
+				} else if i == ticks / 8 {
+					if self.ascii { '>' } else { [' ', '▏', '▎', '▍', '▌', '▋', '▊', '▉'][ticks % 8] }
+				} else {
+					' '
+				})?;
+				i += 1;
+			}
+		}
+		Ok(())
+	}
+}

--- a/src/status/progressbar.rs
+++ b/src/status/progressbar.rs
@@ -9,24 +9,45 @@ pub struct ProgressBar<'a> {
 
 impl<'a> std::fmt::Display for ProgressBar<'a> {
 	fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-		let ticks = (self.progress * self.width as f64 * 8.0) as usize;
+		if self.label.len() > self.width {
+			f.write_str(&self.label[..self.width])?;
+			return Ok(());
+		}
+
+		let fancy_blocks = [' ', '▏', '▎', '▍', '▌', '▋', '▊', '▉'];
+
+		let ticks = (self.progress * self.width as f64 * fancy_blocks.len() as f64) as usize;
 		let label_pos = (self.width - self.label.len()) / 2;
+		f.write_str("\x1b[32m")?;
 		let mut i = 0;
 		while i < self.width {
 			if i == label_pos && !self.label.is_empty() {
+				f.write_str("\x1b[m")?;
 				f.write_str(self.label)?;
+				f.write_str("\x1b[32m")?;
 				i += self.label.len();
 			} else {
-				f.write_char(if i < ticks / 8 {
-					if self.ascii { '=' } else if i + 1 == label_pos { '▉' } else { '█' }
-				} else if i == ticks / 8 {
-					if self.ascii { '>' } else { [' ', '▏', '▎', '▍', '▌', '▋', '▊', '▉'][ticks % 8] }
+				f.write_char(if i < ticks / fancy_blocks.len() {
+					if self.ascii {
+						'='
+					} else if i + 1 == label_pos {
+						fancy_blocks[5]
+					} else {
+						fancy_blocks[7]
+					}
+				} else if i == ticks / fancy_blocks.len() {
+					if self.ascii {
+						'>'
+					} else {
+						fancy_blocks[ticks % 8]
+					}
 				} else {
 					' '
 				})?;
 				i += 1;
 			}
 		}
+		f.write_str("\x1b[m")?;
 		Ok(())
 	}
 }

--- a/src/status/progressbar.rs
+++ b/src/status/progressbar.rs
@@ -34,7 +34,7 @@ impl<'a> std::fmt::Display for ProgressBar<'a> {
 					if self.ascii {
 						'>'
 					} else {
-						blocks[ticks % 8]
+						blocks[ticks % blocks.len()]
 					}
 				} else {
 					' '


### PR DESCRIPTION
This patch adds the -P / --progress option to ninj, which sets the type of
progress display. There are currently six options: no progress display (`none`),
display in text (`text`), display a progress bar in ASCII (`ascii`), use fancy
Unicode characters (`highres`), and for the last two a `.split` mode which
splits the texts into three locations and shows all three of them at all times.

The term_size dependency is added for establishing the width of the terminal.

A bug is fixed causing the final time estimation to be unknown, caused by all
workers being Done.

[![asciicast](https://asciinema.org/a/tA51OCAp5wovyxgt6cCd0jEjj.png)](https://asciinema.org/a/tA51OCAp5wovyxgt6cCd0jEjj)